### PR TITLE
"Tests need to pass" fix in "Sequence Reductions"

### DIFF
--- a/src/clj/sub_chapters/medium.clj
+++ b/src/clj/sub_chapters/medium.clj
@@ -419,7 +419,7 @@
                                                         (p "Tests need to pass:")
                                                         (code (= (take 5 (my-reduce + (range))) [0 1 3 6 10]))
                                                         (code (= (my-reduce conj [1] [2 3 4]) [[1] [1 2] [1 2 3] [1 2 3 4]]))
-                                                        (code (= (my-last ["b" "c" "d"]) "d")))
+                                                        (code (= (last (my-reduce * 2 [3 4 5])) (reduce * 2 [3 4 5]) 120)))
                                                       (testing
                                                         (is (= (take 5 (my-reduce + (range))) [0 1 3 6 10]) :default :advanced)
                                                         (is (= (my-reduce conj [1] [2 3 4]) [[1] [1 2] [1 2 3] [1 2 3 4]]) :default :advanced)


### PR DESCRIPTION
This exercise doesn't ask the user to implement `my-last`; corrects the third stated test case in the instruction `text` to match what is actually tested in the `testing` list.